### PR TITLE
Lazy load App::CPANTS::Lint

### DIFF
--- a/lib/Dist/Zilla/App/Command/kwalitee.pm
+++ b/lib/Dist/Zilla/App/Command/kwalitee.pm
@@ -5,7 +5,6 @@ use strict;
 use warnings;
 
 use Dist::Zilla::App -command;
-use App::CPANTS::Lint 0.03;
 
 sub abstract { 'run CPANTS kwalitee check on your dist' }
 
@@ -30,6 +29,9 @@ sub opt_spec {
 
 sub execute {
     my ($self, $opt, $arg) = @_;
+
+    require App::CPANTS::Lint;
+    App::CPANTS::Lint->VERSION('0.03');
 
     my $tgz = $self->zilla->build_archive;
     my $linter = App::CPANTS::Lint->new();


### PR DESCRIPTION
Because all DZAC plugins are loaded for any command run (ex: kwalitee will be loaded when we run just `dzil nop`), each plugin must be light to not impact the global performance of dzil. The fix is to not load dependencies at compile time, but only when needed, in the `execute` method.
